### PR TITLE
float typed array now supports int assigment

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -362,9 +362,12 @@ void Array::remove_at(int p_pos) {
 
 void Array::set(int p_idx, const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	ERR_FAIL_COND(!_p->typed.validate(p_value, "set"));
-
-	operator[](p_idx) = p_value;
+	Variant casted_variant = Variant(p_value);
+	if (_p->typed.type == Variant::FLOAT && p_value.get_type() == Variant::INT) {
+		casted_variant = static_cast<float>(p_value);
+	}
+	ERR_FAIL_COND(!_p->typed.validate(casted_variant, "set"));
+	operator[](p_idx) = casted_variant;
 }
 
 const Variant &Array::get(int p_idx) const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
